### PR TITLE
Improved the Documentation

### DIFF
--- a/exampleSite/content/home/skills.md
+++ b/exampleSite/content/home/skills.md
@@ -30,17 +30,17 @@ feature:
   name: Photography
 
 # Uncomment to use emoji icons.
-#- icon = ":smile:"
-#  icon_pack = "emoji"
-#  name = "Emojiness"
-#  description = "100%"  
+#- icon: ':smile:'
+#  icon_pack: emoji
+#  name: Emojiness
+#  description: 100% 
 
 # Uncomment to use custom SVG icons.
-# Place custom SVG icon in `assets/media/icons/`, creating folders if necessary.
+# Place your custom SVG icon in `assets/media/icons/`.
 # Reference the SVG icon name (without `.svg` extension) in the `icon` field.
-# If your icon is at assets/media/icons/xyz/abc.svg then refer it as xyz/abc
-#- icon = "your-custom-icon-name"
-#  icon_pack = "custom"
-#  name = "Surfing"
-#  description = "90%"
+# For example, reference `assets/media/icons/xyz.svg` as `icon: 'xyz'`
+#- icon: your-custom-icon-name
+#  icon_pack: custom
+#  name: Surfing
+#  description: 90%
 ---

--- a/exampleSite/content/home/skills.md
+++ b/exampleSite/content/home/skills.md
@@ -36,8 +36,9 @@ feature:
 #  description = "100%"  
 
 # Uncomment to use custom SVG icons.
-# Place custom SVG icon in `assets/images/icon-pack/`, creating folders if necessary.
+# Place custom SVG icon in `assets/media/icons/`, creating folders if necessary.
 # Reference the SVG icon name (without `.svg` extension) in the `icon` field.
+# If your icon is at assets/media/icons/xyz/abc.svg then refer it as xyz/abc
 #- icon = "your-custom-icon-name"
 #  icon_pack = "custom"
 #  name = "Surfing"


### PR DESCRIPTION
There was a confusion between the option on where to upload the custom svgs. in the markdown it was /assets/images/icon-pack  in comments ,but that wasnt working after reading documentation page it became clear that we have to save in /assets/media/icons/ and not only that another feature was undocumented which was if you save it into a directory inside , say /assets/media/icons/xyz/abc.svg then it can be accessed by using the xyz/abc option into icon field