### PR TITLE
Rename cms branch param from master -> main

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -99,7 +99,7 @@ features:
 
 extensions:
   cms:
-    branch: master
+    branch: main
     local_backend: false
   academicons:
     enable: true


### PR DESCRIPTION
Github has changed from using master -> main as the default branch for new repos.  So when netlify creates a new repo based on this template, the default branch is named 'main' instead of 'master'

Leaving this config param as 'master' will result in a credentials error whenever a user tries to login using the /admin page. Renaming this to 'main' fixes the error.