### PR TITLE
site title points to parent directory instead of home. 

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,0 +1,217 @@
+{{ $show_navbar := ((site.Params.header.navbar.enable | default true) | and (ne .Params.header.navbar.enable false)) | or .Params.header.navbar.enable }}
+{{ if $show_navbar }}
+
+{{ $current_page := . }}
+{{ $highlight_active_link := site.Params.header.navbar.highlight_active_link | default true }}
+{{ $show_current_language := site.Params.header.navbar.show_language | default false }}
+
+{{/* Get site logo. */}}
+{{ $show_logo := site.Params.header.navbar.show_logo | default true }}
+{{ $has_logo := fileExists "assets/media/logo.png" | or (fileExists "assets/media/logo.svg") }}
+{{ $logo := "" }}
+{{ if $has_logo }}
+  {{ $logo = (partial "functions/get_logo" (dict "constraint" "max_height" "size" 70)) }}
+{{ end }}
+
+<header>
+  <nav class="navbar navbar-expand-lg navbar-light compensate-for-scrollbar" id="navbar-main">
+    <div class="container-xl">
+
+      {{if $show_logo}}
+      <div class="d-none d-lg-inline-flex">
+        <a class="navbar-brand" href="{{ site.Home.RelPermalink }}">
+          {{- if $has_logo -}}
+            <img src="{{ $logo.RelPermalink }}" alt="{{ site.Title }}"
+            {{with site.Params.header.image.width}}width="{{.}}"{{end}}
+            {{with site.Params.header.image.height}}height="{{.}}"{{end}}>
+          {{- else -}}
+            {{- site.Title -}}
+          {{- end -}}
+        </a>
+      </div>
+      {{end}}
+
+      {{ if site.Menus.main }}
+      <button type="button" class="navbar-toggler" data-toggle="collapse"
+              data-target="#navbar-content" aria-controls="navbar-content" aria-expanded="false" aria-label="{{ i18n "toggle_navigation" }}">
+      <span><i class="fas fa-bars"></i></span>
+      </button>
+      {{ end }}
+
+      {{if $show_logo}}
+      <div class="navbar-brand-mobile-wrapper d-inline-flex d-lg-none">
+        <a class="navbar-brand" href="{{ site.Home.RelPermalink }}">
+        {{- if $has_logo -}}
+          <img src="{{ $logo.RelPermalink }}" alt="{{ site.Title }}"
+          {{with site.Params.header.image.width}}width="{{.}}"{{end}}
+          {{with site.Params.header.image.height}}height="{{.}}"{{end}}>
+        {{- else -}}
+          {{- site.Title -}}
+        {{- end -}}
+        </a>
+      </div>
+      {{end}}
+
+      <!-- Collect the nav links, forms, and other content for toggling -->
+      {{ $align_menu := site.Params.header.navbar.align | default "l" }}
+      <div class="navbar-collapse main-menu-item collapse {{ if eq $align_menu "c" }}justify-content-center{{ else if eq $align_menu "r" }}justify-content-end{{else}}justify-content-start{{ end }}" id="navbar-content">
+
+        <!-- Left Nav Bar -->
+        <ul class="navbar-nav d-md-inline-flex">
+          {{ range site.Menus.main }}
+
+          {{ if .HasChildren }}
+          <li class="nav-item dropdown">
+            <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true">
+              {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
+              <span class="caret"></span>
+            </a>
+            <div class="dropdown-menu">
+              {{ range .Children }}
+                <a class="dropdown-item" href="{{ .URL | relLangURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}>
+                  {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
+                </a>
+              {{ end }}
+            </div>
+          </li>
+
+          {{ else }}
+
+          {{/* Set target for link. */}}
+          {{ $.Scratch.Set "target" "" }}
+          {{ if gt (len .URL) 4 }}
+            {{ if eq "http" (slicestr .URL 0 4) }}
+              {{ $.Scratch.Set "target" " target=\"_blank\" rel=\"noopener\"" }}
+            {{ end }}
+          {{ end }}
+
+          {{/* Get active page. */}}
+
+          {{ $is_link_in_current_path := false }}
+          {{ $is_widget_page := or $current_page.IsHome (eq $current_page.Type "widget_page") }}
+          {{ $is_same_page := false }}
+          {{ $hash := findRE "#(.+)" .URL }}
+
+          {{ if $current_page.IsHome | and (or (eq .URL "/") (eq .URL "")) }}
+            {{ $is_link_in_current_path = true }}
+          {{else}}
+            {{ if gt (len .URL) 1 }}{{/* Ignore root URL */}}
+              {{ $is_link_in_current_path = in $current_page.RelPermalink .URL }}
+              {{ $is_same_page = $is_link_in_current_path }}
+            {{end}}
+            {{ if gt (len $hash) 0 }}
+              {{ $hash = index $hash 0 }}
+              {{ $hash_removed := replace .URL $hash "" }}
+              {{ if eq (len $hash_removed) 0 }}
+                {{ $hash_removed = "/" }}{{/* Add robustness for `/#SECTION` or `#SECTION` in `menus.toml`. */}}
+              {{ end }}
+              {{ $is_same_page = eq (path.Dir $current_page.RelPermalink) (path.Dir ($hash_removed|relLangURL)) }}
+            {{ end }}
+          {{end}}
+
+          <li class="nav-item">
+            <a class="nav-link {{if and $highlight_active_link $is_link_in_current_path }} active{{end}}" href="{{.URL | relLangURL}}"{{ if and $is_widget_page $is_same_page }} data-target="{{$hash}}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+              {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
+            </a>
+          </li>
+
+          {{ end }}
+          {{ end }}
+
+        {{ if site.Menus.main_right | and (eq $align_menu "l") }}
+        </ul>
+        <ul class="navbar-nav ml-md-auto">
+        {{ end }}
+
+          {{ range site.Menus.main_right }}
+
+          {{/* Set target for link. */}}
+          {{ $.Scratch.Set "target" "" }}
+          {{ if gt (len .URL) 4 }}
+          {{ if eq "http" (slicestr .URL 0 4) }}
+          {{ $.Scratch.Set "target" " target=\"_blank\" rel=\"noopener\"" }}
+          {{ end }}
+          {{ end }}
+
+          <li class="nav-item">
+            <a class="nav-link" href="{{ .URL | relLangURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>
+              {{- .Pre -}}<span>{{ .Name | safeHTML }}</span>{{- .Post -}}
+            </a>
+          </li>
+
+          {{ end }}
+        </ul>
+      </div><!-- /.navbar-collapse -->
+
+      <ul class="nav-icons navbar-nav flex-row ml-auto d-flex pl-md-2">
+
+        {{/* Display any social links that the superuser chose to display in the header. */}}
+        {{ range where (where (where site.Pages "Section" "authors") ".Params.superuser" true) ".Params.social" "!=" nil }}
+          {{ range where .Params.social ".display.header" true }}
+            {{ $social_link := partial "functions/get_social_link" . }}
+            <li class="nav-item d-none d-lg-inline-flex">
+              <a class="nav-link" href="{{ $social_link.link | safeURL }}"{{ with $social_link.tooltip }} data-toggle="tooltip" data-placement="bottom" title="{{.}}"{{ end }} {{ $social_link.target | safeHTMLAttr }} aria-label="{{ $social_link.aria_label }}">
+                <i class="{{ $social_link.icon_pack }} {{ $social_link.pack_prefix }}-{{ $social_link.icon }}" aria-hidden="true"></i>
+              </a>
+            </li>
+          {{ end }}
+        {{ end }}
+
+        {{/* Override: hide search icon if provider is Docsearch so we only show Docsearch once in the docs sidebar. */}}
+        {{ $show_search := site.Params.header.navbar.show_search | default true }}
+        {{ if and site.Params.features.search.provider $show_search | and (ne (lower site.Params.features.search.provider) "docsearch") }}
+        <li class="nav-item">
+          <a class="nav-link js-search" href="#" aria-label="{{ i18n "search" }}"><i class="fas fa-search" aria-hidden="true"></i></a>
+        </li>
+        {{ end }}
+
+        {{ $show_day_night := site.Params.header.navbar.show_day_night | default true }}
+        {{ $has_day_night_themes := (and site.Params.appearance.theme_day site.Params.appearance.theme_night) }}
+        {{ if and $has_day_night_themes $show_day_night }}
+        <li class="nav-item dropdown theme-dropdown">
+          <a href="#" class="nav-link" data-toggle="dropdown" aria-haspopup="true" aria-label="{{ i18n "theme_selector" | default "Display preferences" }}">
+            <i class="fas fa-moon" aria-hidden="true"></i>
+          </a>
+          <div class="dropdown-menu">
+            <a href="#" class="dropdown-item js-set-theme-light">
+              <span>{{ i18n "theme_light" | default "Light" }}</span>
+            </a>
+            <a href="#" class="dropdown-item js-set-theme-dark">
+              <span>{{ i18n "theme_dark" | default "Dark" }}</span>
+            </a>
+            <a href="#" class="dropdown-item js-set-theme-auto">
+              <span>{{ i18n "theme_auto" | default "Automatic" }}</span>
+            </a>
+          </div>
+        </li>
+        {{ end }}
+
+        {{ $show_translations := site.Params.header.navbar.show_translations | default true }}
+        {{ if .IsTranslated | and $show_translations }}
+        <li class="nav-item dropdown i18n-dropdown">
+          <a href="#" class="nav-link {{ if $show_current_language }}dropdown-toggle{{end}}" data-toggle="dropdown"
+             aria-haspopup="true" aria-label="{{ i18n "languages" | default "Languages" }}">
+            <i class="fas fa-globe mr-1" aria-hidden="true"></i>
+            {{- if $show_current_language -}}
+              <span class="d-none d-lg-inline">{{ index site.Data.i18n.languages .Lang }}</span>
+            {{- end -}}
+          </a>
+          <div class="dropdown-menu">
+            <div class="dropdown-item dropdown-item-active">
+              <span>{{ index site.Data.i18n.languages .Lang }}</span>
+            </div>
+            {{ range .Translations }}
+            <a class="dropdown-item" href="{{ .Permalink }}"{{ if $.IsHome }} data-target="{{ .RelPermalink }}"{{ end }}>
+              <span>{{ index site.Data.i18n.languages .Lang }}</span>
+            </a>
+            {{ end }}
+          </div>
+        </li>
+        {{ end }}
+
+      </ul>
+
+    </div><!-- /.container -->
+  </nav>
+</header>
+{{end}}{{/* End show navbar. */}}


### PR DESCRIPTION
Hi, 

When the BaseURL is a subdirectory (like dept.univ.edu/name), the link in the title points to dept.univ.edu instead of dept.univ.edu/name. A possible workaround is to use: 
```Markdown
relativeURLS: true
canonifyurls: true
```
However, this creates issues with citations. In this [Hugo discourse thread](https://discourse.gohugo.io/t/wrong-navbar-brand-href-attribute-with-wowchemy-academic/41239), jmooring suggested making a couple changes to navbar.html to fix this issue without using relativeURLS. 

**Note:**  The link in the [OP](https://discourse.gohugo.io/t/wrong-navbar-brand-href-attribute-with-wowchemy-academic/41239) are obsolete since I migrated to hmegh.github.io. 